### PR TITLE
Removes tty allocation for automated builds.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ all: duopull
 
 # Package lambda function in zip file
 package:
-	docker run -t -i --rm -v `pwd`:/go/src/github.com/mozilla-services/duopull-lambda \
+	docker run -i --rm -v `pwd`:/go/src/github.com/mozilla-services/duopull-lambda \
 		golang:1.7 \
 		/bin/bash -c 'cd /go/src/github.com/mozilla-services/duopull-lambda && make lambda'
 


### PR DESCRIPTION
This is needed to build successfully from our automation system without getting the following error:

> the input device is not a TTY